### PR TITLE
Fix issue with --- still being required at foot of slide

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ Consul     #CA2171
            // Files shouldn't have --- at the head or foot
            // It is added automatically here
            if (i + 1 < sourceUrls.length) {
-             source += "---"
+             source += "---\n---"
            }
        };
        var slideshow = remark.create({

--- a/slide1.md
+++ b/slide1.md
@@ -12,4 +12,4 @@ This slide uses the `img-right` class and displays an image
 
 ???
 
----
+This is a presenter note

--- a/slide2.md
+++ b/slide2.md
@@ -17,3 +17,5 @@ Here's an example of incremental text (hit left to progress):
 - List Item 3
 
 ???
+
+This is a presenter note

--- a/title.md
+++ b/title.md
@@ -12,5 +12,3 @@ count: false
 
 <!-- Presenter notes go here -->
 Anything under the ??? are presenter notes
-
----


### PR DESCRIPTION
# Pull request
## Description

```javascript
      // Files shouldn't have --- at the head or foot
      // It is added automatically here
      if (i + 1 < sourceUrls.length) {
        source += "---"
      }
```
Based off this comment in `index.html` each individual slide should not need to have a leading or trailing `---`, but currently this does not work correctly.

The `intro.md` and `slide1.md` slides have a trailing `---` at the foot of the file which allows the files to be split into individual pages.

The `slide2.md` file lacks the trailing `---` and matching that style on the previous or future slides leads to files being merged into a single slide.

By adding `source += "---\n---"` instead, we can remove the footer `---` from all slides and still have them display correctly.

## Expectation

Please check all the relevant components;

- [x] Code review && test


## How to

- Pull this project and create a local webserver to serve its directory using the instructions listed in the `README.md`.
- Create a new slide and do not add a trailing `---` to the footer.
- Add the new slide to the `sourceUrls` array in `index.html`.
- Observe the slides properly separated.

## Alternatives

If the functionality listed in the comment in `index.html` isn't actually desired the comment can be changed.